### PR TITLE
Removed the `GTID` field from the `GaleraState` struct

### DIFF
--- a/pkg/galera/galera_test.go
+++ b/pkg/galera/galera_test.go
@@ -71,12 +71,11 @@ safe_to_bootstrap: 0`,
 				Version:         "2.1",
 				UUID:            "05f061bd-02a3-11ee-857c-aa370ff6666b",
 				Seqno:           1,
-				GTID:            &GTID{DomainID: 0, ServerID: 1, SequenceNumber: 2},
 				SafeToBootstrap: true,
 			},
 			want: `version: 2.1
 uuid: 05f061bd-02a3-11ee-857c-aa370ff6666b
-seqno: 1,0-1-2
+seqno: 1
 safe_to_bootstrap: 1`,
 			wantErr: false,
 		},
@@ -242,7 +241,6 @@ safe_to_bootstrap: 1`),
 				Version:         "2.1",
 				UUID:            "05f061bd-02a3-11ee-857c-aa370ff6666b",
 				Seqno:           1,
-				GTID:            &GTID{DomainID: 0, ServerID: 1, SequenceNumber: 2},
 				SafeToBootstrap: true,
 			},
 		},


### PR DESCRIPTION
As we're still not sure what to do on the operator side with the GTID we decided to not export it in the `GaleraState`. It would also force us to import the `GaleraState` struct to the operator repository so we chose to just not export it for the moment instead.

https://mariadb-operator.slack.com/archives/C056RAECH0W/p1699990598511999?thread_ts=1699350363.009529&cid=C056RAECH0W